### PR TITLE
[FIX] prevent adding private phase without merkle root

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -13,10 +13,12 @@ url = "https://api.apr.dev"
 
 [provider]
 cluster = "Localnet"
-wallet = "~/.config/solana/id.json"
+### @dev testing wallet
+### wallet = "~/.config/solana/id.json"
+wallet = "usb://ledger"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 test/tests/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 test/tests/**/*.ts"
 
 [test]
 startup_wait = 100000
@@ -25,9 +27,9 @@ upgradeable = false
 
 [test.validator]
 bind_address = "0.0.0.0"
-### @dev: Utilize the testnet cluster for running the testsuite
-url = "https://api.testnet.solana.com"
-### url = "https://api.mainnet-beta.solana.com"
+### @dev: Utilize the testnet cluster for running test-suite with anchor test
+### url = "https://api.testnet.solana.com"
+url = "https://api.mainnet-beta.solana.com"
 ledger = ".anchor/test-ledger"
 rpc_port = 8899
 

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -5,20 +5,18 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-libreplex_editions = "GHVmd43GebD2SSedqG1AAh76izf5CPAhz6KotkZyRzUD"
-libreplex_editions_controls = "CCWfNBFcrjbKSjKes9DqgiQYsnmCFgCVKx21mmV2xWgN"
+libreplex_editions = "A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ"
+libreplex_editions_controls = "5GSxbLSQms8VoBmNPEsPPyr8TtSApX19cP8jAg4isJ3K"
 
 [registry]
 url = "https://api.apr.dev"
 
 [provider]
 cluster = "Localnet"
-### @dev testing wallet
-# wallet = "~/.config/solana/id.json"
-wallet = "usb://ledger"
+wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 test/tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 test/tests/*.ts"
 
 [test]
 startup_wait = 100000
@@ -28,8 +26,8 @@ upgradeable = false
 [test.validator]
 bind_address = "0.0.0.0"
 ### @dev: Utilize the testnet cluster for running the testsuite
-# url = "https://api.testnet.solana.com"
-url = "https://api.mainnet-beta.solana.com"
+url = "https://api.testnet.solana.com"
+### url = "https://api.mainnet-beta.solana.com"
 ledger = ".anchor/test-ledger"
 rpc_port = 8899
 
@@ -47,4 +45,3 @@ address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
 
 [[test.validator.clone]]
 address = "5hx15GaPPqsYA61v6QpcGPpo125v7rfvEfZQ4dJErG5V"
-

--- a/programs/libreplex_editions/src/lib.rs
+++ b/programs/libreplex_editions/src/lib.rs
@@ -2,7 +2,8 @@ use anchor_lang::prelude::*;
 
 pub mod instructions;
 pub use instructions::*;
-declare_id!("GHVmd43GebD2SSedqG1AAh76izf5CPAhz6KotkZyRzUD");
+
+declare_id!("A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ");
 
 pub mod errors;
 pub mod state;

--- a/programs/libreplex_editions_controls/src/instructions/add_phase.rs
+++ b/programs/libreplex_editions_controls/src/instructions/add_phase.rs
@@ -48,6 +48,11 @@ pub fn add_phase(ctx: Context<AddPhaseCtx>, input: InitialisePhaseInput) -> Resu
     if !input.price_token.eq(&wrapped_sol::ID) {
         panic!("Only native price currently supported")
     }
+
+    if input.is_private && input.merkle_root.is_none() {
+        panic!("Merkle root must be provided for private phases");
+    }
+
     let editions_controls = &mut ctx.accounts.editions_controls;
 
     editions_controls.phases.push(Phase{ 

--- a/programs/libreplex_editions_controls/src/lib.rs
+++ b/programs/libreplex_editions_controls/src/lib.rs
@@ -5,7 +5,7 @@ pub use logic::*;
 
 pub mod instructions;
 pub use instructions::*;
-declare_id!("CCWfNBFcrjbKSjKes9DqgiQYsnmCFgCVKx21mmV2xWgN");
+declare_id!("5GSxbLSQms8VoBmNPEsPPyr8TtSApX19cP8jAg4isJ3K");
 
 pub mod errors;
 pub mod state;

--- a/target/types/libreplex_editions.ts
+++ b/target/types/libreplex_editions.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/libreplex_editions.json`.
  */
 export type LibreplexEditions = {
-  "address": "5hx15GaPPqsYA61v6QpcGPpo125v7rfvEfZQ4dJErG5V",
+  "address": "A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ",
   "metadata": {
     "name": "libreplexEditions",
     "version": "0.2.1",

--- a/target/types/libreplex_editions_controls.ts
+++ b/target/types/libreplex_editions_controls.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/libreplex_editions_controls.json`.
  */
 export type LibreplexEditionsControls = {
-  "address": "CCWfNBFcrjbKSjKes9DqgiQYsnmCFgCVKx21mmV2xWgN",
+  "address": "5GSxbLSQms8VoBmNPEsPPyr8TtSApX19cP8jAg4isJ3K",
   "metadata": {
     "name": "libreplexEditionsControls",
     "version": "0.2.1",
@@ -51,7 +51,7 @@ export type LibreplexEditionsControls = {
         },
         {
           "name": "libreplexEditionsProgram",
-          "address": "GHVmd43GebD2SSedqG1AAh76izf5CPAhz6KotkZyRzUD"
+          "address": "A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ"
         }
       ],
       "args": [
@@ -152,7 +152,7 @@ export type LibreplexEditionsControls = {
         },
         {
           "name": "libreplexEditionsProgram",
-          "address": "GHVmd43GebD2SSedqG1AAh76izf5CPAhz6KotkZyRzUD"
+          "address": "A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ"
         }
       ],
       "args": [
@@ -365,7 +365,7 @@ export type LibreplexEditionsControls = {
         },
         {
           "name": "libreplexEditionsProgram",
-          "address": "GHVmd43GebD2SSedqG1AAh76izf5CPAhz6KotkZyRzUD"
+          "address": "A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ"
         }
       ],
       "args": [
@@ -595,7 +595,7 @@ export type LibreplexEditionsControls = {
         },
         {
           "name": "libreplexEditionsProgram",
-          "address": "GHVmd43GebD2SSedqG1AAh76izf5CPAhz6KotkZyRzUD"
+          "address": "A927QYSgP2fJWWDJn1gZknSfsMXyyKnJvMf2kJoY5yeQ"
         }
       ],
       "args": [


### PR DESCRIPTION
Fixed this low risk error where a phase was able to be created privately without allow-list (prone to human error), where nobody could mint. Added unit test to cover the case.